### PR TITLE
Fix "previous definition" error from KalmanMuonCalibrator.h

### DIFF
--- a/Calibration/interface/KalmanMuonCalibrator.h
+++ b/Calibration/interface/KalmanMuonCalibrator.h
@@ -1,3 +1,6 @@
+#ifndef KalmanMuonCalibrator_h
+#define KalmanMuonCalibrator_h
+
 #include "TFile.h"
 #include "TH3F.h"
 #include "TH2F.h"
@@ -81,3 +84,5 @@ class KalmanMuonCalibrator {
 
 
 };
+
+#endif


### PR DESCRIPTION
When calling the KalmanMuonCalibrator class from a different module in C++, get the following error:
error: previous definition of 'class KalmanMuonCalibrator'
Fixed with #ifndef statement.