### PR TITLE
Fix compile errors and warnings

### DIFF
--- a/Calibration/interface/KalmanMuonCalibrator.h
+++ b/Calibration/interface/KalmanMuonCalibrator.h
@@ -1,3 +1,6 @@
+#ifndef KalmanMuonCalibrator_h
+#define KalmanMuonCalibrator_h
+
 #include "TFile.h"
 #include "TH3F.h"
 #include "TH2F.h"
@@ -77,3 +80,5 @@ class KalmanMuonCalibrator {
 
 
 };
+
+#endif // #define KalmanMuonCalibrator_h

--- a/Derivation/src/DataEBEEstimator.cc
+++ b/Derivation/src/DataEBEEstimator.cc
@@ -91,7 +91,7 @@ void DataEBEEstimator::processTree(const std::string&fileName,const std::string&
   float x=0.0;
 
 
-  TRandom *random = new TRandom(10101982);
+  // TRandom *random = new TRandom(10101982);
 
   for (int i=0;i<entries;++i) {
     reduced->GetEntry(i);
@@ -144,7 +144,7 @@ void DataEBEEstimator::processTree(const std::string&fileName,const std::string&
       x=genMass;
 
 
-      histoMap_[bin2]->Fill(x);
+    histoMap_[bin2]->Fill(x);
 
     if (i % 1000000==0)
 	printf("Processed %d \%d entries\n",i,entries);

--- a/Derivation/src/RooGaussianSumPdfWithSigma.cc
+++ b/Derivation/src/RooGaussianSumPdfWithSigma.cc
@@ -62,7 +62,7 @@ Double_t RooGaussianSumPdfWithSigma::evaluate() const
     //protection!
     if (error<=0.0)
       continue;
-      error=sqrt(error);
+    error=sqrt(error);
     arg = (mass-scale*masses[i])/(error);
     sum=sum+weights[i]*exp(-0.5*arg*arg)/(rootPiTimes2*error);
     sumw=sumw+weights[i];


### PR DESCRIPTION
@bachtis : Fix compile error for reader redefinition, and warnings about unused variables and misleading indents

Cheers, Andrew